### PR TITLE
增加一些对非推荐规范的ofd文件支持：资源相对路径，空的DocumentRes.xml

### DIFF
--- a/easyofd/parser_ofd/file_deal.py
+++ b/easyofd/parser_ofd/file_deal.py
@@ -59,8 +59,12 @@ class FileRead(object):
                 
                 abs_path = os.path.join(root,file)
                 # 资源文件 则 b64 xml 则  xml——obj
-                self.file_tree[abs_path] = str(base64.b64encode(open(f"{abs_path}","rb").read()),"utf-8")  \
+                # DocumentRes.xml 允许为空
+                try:
+                    self.file_tree[abs_path] = str(base64.b64encode(open(f"{abs_path}","rb").read()),"utf-8")  \
                     if "xml" not in file else xmltodict.parse(open(f"{abs_path}" , "r", encoding="utf-8").read())
+                except:
+                    self.file_tree[abs_path] = str(base64.b64encode(open(f"{abs_path}","rb").read()),"utf-8")
         self.file_tree["root_doc"] = os.path.join(self.unzip_path,"OFD.xml") if os.path.join(self.unzip_path,"OFD.xml") in self.file_tree else ""
   
         if os.path.exists(self.unzip_path):

--- a/easyofd/parser_ofd/ofd_parser.py
+++ b/easyofd/parser_ofd/ofd_parser.py
@@ -98,8 +98,15 @@ class OFDParser(object):
         assert label
         # print(self.file_tree.keys())
         for abs_p in self.file_tree:
-            # 统一符号，避免win linux 路径冲突
+            # 路径可能为相对路径，如 ./Doc_0/Document.xml
+            label = os.path.normpath(label)
+            # 即使在 normpath 之后，也有可能以 ./ 或 ../ 开头
+            while label.startswith("./"):
+                label = label[2:]
+            while label.startswith("../"):
+                label = label[3:]
 
+            # 统一符号，避免win linux 路径冲突
             abs_p_compare = abs_p.replace("\\\\", "-").replace("//", "-").replace("\\", "-").replace("/", "-")
             label_compare = label.replace("\\\\", "-").replace("//", "-").replace("\\", "-").replace("/", "-")
             if label_compare in abs_p_compare:
@@ -120,6 +127,11 @@ class OFDParser(object):
         # todo ib2 转png C:/msys64/mingw64/bin/jbig2dec.exe -o F:\code\easyofd\test\image_80.png F:\code\easyofd\test\image_80.jb2
         fileName = img_d["fileName"]
         new_fileName = img_d['fileName'].replace(".jb2", ".png")
+        # 路径包含多层文件夹，需要创建文件夹
+        dirName = os.path.dirname(fileName)
+        if dirName and not os.path.exists(dirName):
+            os.makedirs(dirName)
+            
         with open(fileName, "wb") as f:
             f.write(base64.b64decode(img_d["imgb64"]))
         command = "{} -o {} {}"
@@ -143,6 +155,11 @@ class OFDParser(object):
 
         fileName = img_d["fileName"]
         new_fileName = img_d['fileName'].replace(".bmp", ".jpg")
+        # 路径包含多层文件夹，需要创建文件夹
+        dirName = os.path.dirname(fileName)
+        if dirName and not os.path.exists(dirName):
+            os.makedirs(dirName)
+        
         with open(fileName, "wb") as f:
             f.write(base64.b64decode(img_d["imgb64"]))
 


### PR DESCRIPTION
可以通过以下文件的测试：
```bash
6.2.003 使用相对路径.ofd
6.2.004_1 文件目录结构与推荐的不符.ofd
6.2.004_2 路径中含有空格.ofd
6.2.004_3 路径中含有转义字符.ofd
```
主要修复的问题：
1. 相对路径的处理
2. 资源文件的多级目录处理
3. DocumentRes.xml 可能为空的处理