### PR TITLE
fix(draw): fix PDF to OFD converter

### DIFF
--- a/easyofd/draw/draw_pdf.py
+++ b/easyofd/draw/draw_pdf.py
@@ -146,7 +146,7 @@ class DrawPDF():
             try:
                 c.setFont(font, line_dict["size"] * self.OP)
             except KeyError as key_error:
-                logger.error(f"{key_error}")
+                logger.error(f"font({font}) not found: {key_error}")
                 font =  self.font_tool.FONTS[0]
                 c.setFont(font, line_dict["size"] * self.OP)
             # 原点在页面的左下角 
@@ -654,7 +654,7 @@ class DrawPDF():
                 file_name = font_v.get("FontFile")
                 font_b64 = font_v.get("font_b64")
                 if font_b64:
-                    self.font_tool.register_font(os.path.split(file_name)[1], font_v.get("@FontName"), font_b64)
+                    self.font_tool.register_font(os.path.split(file_name)[1], font_v.get("FontName"), font_b64)
             # text_write = []
             # print("doc.get(page_info)", len(doc.get("page_info")))
             for page_id, page in doc.get("page_info").items():

--- a/easyofd/draw/font_tools.py
+++ b/easyofd/draw/font_tools.py
@@ -201,6 +201,7 @@ class FontTool(object):
                 # print("FontName", FontName, "file_name", file_name)
                 pdfmetrics.registerFont(TTFont(FontName, file_name))
                 self.FONTS.append(FontName)
+                logger.debug(f"FontTool.register_font success, name={FontName}, file={file_name}")
             except Exception as e:
                 logger.error(f"register_font_error:\n{e} \n 包含不支持解析字体格式")
             finally:

--- a/easyofd/parser_ofd/__init__.py
+++ b/easyofd/parser_ofd/__init__.py
@@ -21,8 +21,8 @@ for font,names in font_map.items():
     for name in names:
         try:
             pdfmetrics.registerFont(TTFont(name, font))
-        except:
-            logger.warning(f"FONT  registerFont failed {font}: {name}")
+        except Exception as e:
+            logger.warning(f"FONT  registerFont failed '{font}'({name}): {e}")
 
 from easyofd.parser_ofd.ofd_parser import OFDParser
 __all__=["OFDParser"]

--- a/easyofd/parser_ofd/file_annotation_parser.py
+++ b/easyofd/parser_ofd/file_annotation_parser.py
@@ -7,6 +7,7 @@
 # NOTE: 注释解析
 from loguru import logger
 from .file_parser_base import FileParserBase
+from .file_publicres_parser import PublicResFileParser
 
 class AnnotationsParser(FileParserBase):
     """
@@ -36,7 +37,7 @@ class AnnotationsParser(FileParserBase):
                 }
 
         return info
-class AnnotationFileParser(FileParserBase):
+class AnnotationFileParser(PublicResFileParser):
     """
     Parser Annotation
     注释类 包含 签名注释 水印注释 信息注释


### PR DESCRIPTION
包含两处修复：
1. 更正文件内嵌字体注册的`FontName`
2. 修复`AnnotationFileParser`无`normalize_font_name`方法报错