### PR TITLE
Fix the inconsistent resizeX/Y in the calculation of offset and font size.

### DIFF
--- a/easyofd/draw/draw_pdf.py
+++ b/easyofd/draw/draw_pdf.py
@@ -176,7 +176,8 @@ class DrawPDF():
                     "moveY": float(CTMS[5]),
 
                 }
-
+                resizeX = CTM_info["resizeX"]
+                resizeY = CTM_info["resizeY"]
             else:
                 CTM_info ={}
             x_list = self.cmp_offset(line_dict.get("pos")[0], X, DeltaX, text, CTM_info, dire="X")


### PR DESCRIPTION
修复存在CTM_info时，计算字符offset和font size使用的resize不一致的问题