### PR TITLE
针对普通发票印章（签章）的优化并解决电子火车票印章（签章）无法识别的问题

### DIFF
--- a/easyofd/draw/draw_pdf.py
+++ b/easyofd/draw/draw_pdf.py
@@ -637,7 +637,8 @@ class DrawPDF():
         """
         img_list = []
         for key, annotation in annota_info.items():
-            if annotation.get("AnnoType").get("type") == "Stamp":
+            #if annotation.get("AnnoType").get("type") == "Stamp":
+            if annotation.get("ImgageObject").get("ResourceID"):
                 pos = annotation.get("ImgageObject").get("Boundary","").split(" ")
                 pos = [float(i) for i in pos] if pos else []
                 wrap_pos = annotation.get("Appearance").get("Boundary","").split(" ")

--- a/easyofd/parser_ofd/file_signature_parser.py
+++ b/easyofd/parser_ofd/file_signature_parser.py
@@ -38,10 +38,10 @@ class SignatureFileParser(FileParserBase):
     签章信息
     """
 
-    def __call__(self, prefix=""):
+    def __call__(self, prefix="", StampAnnot_res_key="ofd:StampAnnot"):
         info = {}
         StampAnnot_res: list = []
-        StampAnnot_res_key = "ofd:StampAnnot"
+        #StampAnnot_res_key = "ofd:StampAnnot"
 
         self.recursion_ext(self.xml_obj, StampAnnot_res, StampAnnot_res_key)
 

--- a/easyofd/parser_ofd/ofd_parser.py
+++ b/easyofd/parser_ofd/ofd_parser.py
@@ -306,6 +306,9 @@ class OFDParser(object):
                     # print(BaseLoc)
                     prefix = BaseLoc.split("/")[0]
                     signatures_info = SignatureFileParser(signature_xml_obj)(prefix=prefix)
+                    if len(signatures_info)==0:
+                        sign_key = list(signature_xml_obj.keys())[0]
+                        signatures_info = SignatureFileParser(signature_xml_obj)(prefix=prefix, StampAnnot_res_key=sign_key)
                     # print(signatures_info)
                     logger.debug(f"signatures_info {signatures_info}")
                     PageRef = signatures_info.get("PageRef")


### PR DESCRIPTION
1. 改进self.OP(针对页面)，从reportlab.lib.units 导入长度单位毫米，并将self.OP定义为1mm，是页面尺寸符合实际大小。
2. 改进draw_chars函数(针对印章): 对有CTM的字符位置，改用reportlab中canvas.transform方法对pdf页面先进行变换再写入字符，使印章文字位置更准确。
3. 改进draw_line函数(针对印章): 对彩色线条，通过提取StrokeColor得到正确的颜色。
4. 改进draw_pdf函数(针对普通发票印章): 绘制顺序由文本(draw_chars)为先，调整为线条(draw_line)为先，这样可以使普通发票的线条在下面，印章文字保持在上面，对于火车票，印章文字和标题文字重叠，目前不起作用。
5. 改进SignatureFileParser函数(针对火车票): 将StampAnnot_res_key = "ofd:StampAnnot"设置为默认传入参数，但对于签章标签名不为"ofd:StampAnnot"的情形，如火车票的为'ofd:Signature'，则从signature_xml_obj.keys()获取。