### PR TITLE
fix(parser_ofd): add empty check for label param in get_xml_obj

### DIFF
--- a/easyofd/parser_ofd/ofd_parser.py
+++ b/easyofd/parser_ofd/ofd_parser.py
@@ -106,7 +106,8 @@ class OFDParser(object):
 
     # 获得xml 对象
     def get_xml_obj(self, label):
-        assert label
+        if not label:
+            return ""
         # print(self.file_tree.keys())
         label =label.lstrip('./')
         for abs_p in self.file_tree:


### PR DESCRIPTION
避免当传入空label时触发断言失败，直接返回空字符串处理异常输入